### PR TITLE
Fix reading power limit on Nvidia GPUs

### DIFF
--- a/src/gpustat/usr/local/emhttp/plugins/gpustat/lib/Nvidia.php
+++ b/src/gpustat/usr/local/emhttp/plugins/gpustat/lib/Nvidia.php
@@ -347,6 +347,9 @@ class Nvidia extends Main
                 if (isset($data->power_readings->power_limit)) {
                     $this->pageData['powermax'] = (string) $this->stripText('.00 W', $data->power_readings->power_limit);
                 }
+                if (isset($data->power_readings->current_power_limit)) {
+                    $this->pageData['powermax'] = (string) $this->stripText('.00 W', $data->power_readings->current_power_limit);
+                }
             }
             if (isset($data->gpu_power_readings)) {
                 if (isset($data->gpu_power_readings->power_draw)) {
@@ -358,6 +361,9 @@ class Nvidia extends Main
                     $this->pageData['power'] = $this->roundFloat($this->pageData['power']) . 'W';
                     }
                 if (isset($data->power_readings->power_limit)) {
+                    $this->pageData['powermax'] = (string) $this->stripText('.00 W', $data->gpu_power_readings->power_limit);
+                }
+                if (isset($data->power_readings->current_power_limit)) {
                     $this->pageData['powermax'] = (string) $this->stripText('.00 W', $data->gpu_power_readings->current_power_limit);
                 }
             }


### PR DESCRIPTION
For some Nvidia GPUs, nvidia-smi does not report `power_limit`, but rather `current_power_limit`. This causes the powermax data field to always be `N/A`, and the power bar in the interface to never fill up. I updated Nvidia.php to read both these fields, with `current_power_limit` being given preference, to fix this.

Sample nvidia-smi of an RTX 2080 Ti (gpu_power_readings section):
```xml
<gpu_power_readings>
        <power_state>P8</power_state>
        <average_power_draw>N/A</average_power_draw>
        <instant_power_draw>2.42 W</instant_power_draw>
        <current_power_limit>250.00 W</current_power_limit>
        <requested_power_limit>250.00 W</requested_power_limit>
        <default_power_limit>250.00 W</default_power_limit>
        <min_power_limit>100.00 W</min_power_limit>
        <max_power_limit>280.00 W</max_power_limit>
</gpu_power_readings>
```